### PR TITLE
Model download formats changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gurobi.log
 BiGG_2.egg-info/
 docs/schema/
 crontab.txt
+bigg2/static/models
 bigg2/static/dumped_models/
 bigg2/static/polished_models/
 bigg2/static/published_models/

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ href="https://github.com/sbrg/ome/tree/bigg">bigg branch</a>.
 To install BiGG, first, follow the OME installation instructions:
 https://github.com/SBRG/ome/blob/bigg/INSTALL.md
 
-Then, BiGG 2 can be installed and run with these commands:
+Then, do the following to get BiGG2 up and running:
 
-```
-python setup.py install # or develop
-python -m bigg2.server --port=8910
-```
+1. Download the code with ```git clone git@github.com:SBRG/BIGG2.git```
+2. ```cd BIGG2```
+3. Install with ```python setup.py develop``` (may need to sudo or add --user)
+4. Generate the static models by running the ```make_all_static_models``` command.
+5. Start the server with ```python -m bigg2.server --port=8910```
 
 Generate a schema browser
 =========================

--- a/bigg2/model_dumper.py
+++ b/bigg2/model_dumper.py
@@ -1,4 +1,4 @@
-from os.path import abspath, dirname, join, isdir
+from os.path import join, isdir
 from os import mkdir, system
 
 import cobra
@@ -7,7 +7,8 @@ from ome.base import Session
 from ome.models import Model
 from ome.dumping.model_dumping import dump_model
 
-static_dir = abspath(join(dirname(__file__), "static", "models"))
+from bigg2.server import static_model_dir as static_dir
+
 if not isdir(static_dir):
     mkdir(static_dir)
 

--- a/bigg2/model_dumper.py
+++ b/bigg2/model_dumper.py
@@ -1,0 +1,54 @@
+from os.path import abspath, dirname, join, isdir
+from os import mkdir, system
+
+import cobra
+
+from ome.base import Session
+from ome.models import Model
+from ome.dumping.model_dumping import dump_model
+
+static_dir = abspath(join(dirname(__file__), "static", "models"))
+if not isdir(static_dir):
+    mkdir(static_dir)
+
+
+def make_all_static_models():
+    """write static models for all models in the database"""
+    failed_models = []
+    session = Session()
+    bigg_ids = [i[0] for i in session.query(Model.bigg_id)]
+    for bigg_id in bigg_ids:
+        # keep track of which models failed
+        if not write_static_model(bigg_id):
+            failed_models.append(bigg_id)
+    session.close()
+    if len(failed_models) > 0:
+        return "Failed for models " + " ".join(failed_models)
+
+
+def write_static_model(bigg_id):
+    """write out static files for a model with the given bigg ID
+
+    This will output compressed and uncompressed SBML L3 + FBCv2, JSON,
+    and MAT files"""
+    success = True
+    model = dump_model(bigg_id)
+    sbml_filepath = join(static_dir, bigg_id + ".xml")
+    try:
+        cobra.io.write_sbml_model(model, sbml_filepath)
+    except Exception as e:
+        success = False
+        print("Failed to export sbml model '%s': %s" % (bigg_id, e.message))
+    else:
+        # TODO polish
+
+        # compress model
+        system("gzip --keep --force --best " + sbml_filepath)
+
+    cobra.io.save_matlab_model(model, join(static_dir, bigg_id + ".mat"))
+    cobra.io.save_json_model(model, join(static_dir, bigg_id + ".json"))
+    return success
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(make_all_static_models())

--- a/bigg2/model_dumper.py
+++ b/bigg2/model_dumper.py
@@ -1,11 +1,13 @@
-from os.path import join, isdir
+from os.path import join, isdir, abspath, dirname
 from os import mkdir, system
+from subprocess import call
 
 import cobra
 
 from ome.base import Session
 from ome.models import Model
 from ome.dumping.model_dumping import dump_model
+from ome import settings
 
 from bigg2.server import static_model_dir as static_dir
 
@@ -13,38 +15,68 @@ if not isdir(static_dir):
     mkdir(static_dir)
 
 
+def autodetect_model_polisher():
+    return abspath(join(dirname(__file__), "..", "bin",
+                        "ModelPolisher-0.8.jar"))
+
+
 def make_all_static_models():
     """write static models for all models in the database"""
     failed_models = []
+    polisher_path = autodetect_model_polisher()
     session = Session()
     bigg_ids = [i[0] for i in session.query(Model.bigg_id)]
     for bigg_id in bigg_ids:
         # keep track of which models failed
-        if not write_static_model(bigg_id):
+        if not write_static_model(bigg_id, polisher_path):
             failed_models.append(bigg_id)
     session.close()
     if len(failed_models) > 0:
         return "Failed for models " + " ".join(failed_models)
 
 
-def write_static_model(bigg_id):
+def write_static_model(bigg_id, model_polisher_path=None):
     """write out static files for a model with the given bigg ID
 
     This will output compressed and uncompressed SBML L3 + FBCv2, JSON,
     and MAT files"""
     success = True
     model = dump_model(bigg_id)
+    raw_sbml_filepath = bigg_id + "_raw.xml"
     sbml_filepath = join(static_dir, bigg_id + ".xml")
+    if model_polisher_path is None:
+        model_polisher_path = autodetect_model_polisher()
     try:
-        cobra.io.write_sbml_model(model, sbml_filepath)
+        cobra.io.write_sbml_model(model, raw_sbml_filepath)
     except Exception as e:
         success = False
         print("Failed to export sbml model '%s': %s" % (bigg_id, e.message))
     else:
-        # TODO polish
+        # polish
+        command = [settings.java,
+                   '-jar',
+                   '-Xms8G',
+                   '-Xmx8G',
+                   '-Xss128M',
+                   '-Duser.language=en',
+                   model_polisher_path,
+                   '--user=%s' % settings.postgres_user,
+                   '--passwd=%s' % settings.postgres_password,
+                   '--host=%s' % settings.postgres_host,
+                   '--dbname=%s' % settings.postgres_database,
+                   '--input=%s' % raw_sbml_filepath,
+                   '--output=%s' % sbml_filepath,
+                   '--compress-output=false',
+                   '--omit-generic-terms=false',
+                   '--log-level=INFO',
+                   '--log-file=model_polisher_%s.log' % bigg_id]
+        polish_result = call(command)
+        if polish_result == 0:
+            # compress model
+            system("gzip --keep --force --best " + sbml_filepath)
+        else:
+            success = False
 
-        # compress model
-        system("gzip --keep --force --best " + sbml_filepath)
 
     cobra.io.save_matlab_model(model, join(static_dir, bigg_id + ".mat"))
     cobra.io.save_json_model(model, join(static_dir, bigg_id + ".json"))

--- a/bigg2/queries.py
+++ b/bigg2/queries.py
@@ -556,18 +556,6 @@ def get_model_list(session):
     return list
 
 
-def get_model_json_string(model_bigg_id):
-    """Get the model JSON for download."""
-    path = join(settings.model_dump_directory,
-                model_bigg_id + '.json')
-    try:
-        with open(path, 'r') as f:
-            data = f.read()
-    except IOError as e:
-        raise NotFoundError(e.message)
-    return data
-
-
 #-------------------------------------------------------------------------------
 # Genes
 #-------------------------------------------------------------------------------

--- a/bigg2/server.py
+++ b/bigg2/server.py
@@ -167,12 +167,12 @@ class BiggStaticFileHandler(StaticFileHandler):
     handled by nginx or apache"""
     def get_content_type(self):
         path = self.absolute_path
-        # need to fix encoding for gzip files until tornado patched
-        # https://github.com/tornadoweb/tornado/pull/1465
+        # need to fix type for gzip files until tornado patched
+        # https://github.com/tornadoweb/tornado/pull/1468
         if path.endswith(".xml.gz"):
-            self.set_header("Content-Encoding", "x-gzip")
+            return "application/gzip"
         # mat needs to be binary
-        if path.endswith(".mat"):
+        elif path.endswith(".mat"):
             return "application/octet-stream"
         else:
             return StaticFileHandler.get_content_type(self)

--- a/bigg2/server.py
+++ b/bigg2/server.py
@@ -8,7 +8,7 @@ from tornado.web import (StaticFileHandler, RequestHandler, asynchronous,
                          HTTPError)
 from tornado.httpclient import AsyncHTTPClient
 from tornado import gen
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, join, isfile, getsize
 from jinja2 import Environment, PackageLoader
 from sqlalchemy.orm import sessionmaker, aliased, Bundle
 from sqlalchemy import create_engine, desc, func, or_
@@ -41,6 +41,7 @@ env = Environment(loader=PackageLoader('bigg2', 'templates'),
 
 # root directory
 directory = abspath(dirname(__file__))
+static_model_dir = join(directory, "static", "models")
 
 # api version
 api_v = 'v2'
@@ -640,6 +641,17 @@ class ModelDownloadHandler(BaseHandler):
 class ModelHandler(BaseHandler):
     def get(self, model_bigg_id):
         result = safe_query(queries.get_model_and_counts, model_bigg_id)
+        # get filesizes
+        for ext in ("xml", "mat", "json", "xml_gz"):
+            fpath = join(static_model_dir,
+                         model_bigg_id + "." + ext.replace("_", "."))
+            byte_size = getsize(fpath) if isfile(fpath) else 0
+            if byte_size > 1048576:
+                result[ext + "_size"] = "%.1f MB" % (byte_size / 1048576.)
+            elif byte_size > 1024:
+                result[ext + "_size"] = "%.1f kB" % (byte_size / 1024.)
+            elif byte_size > 0:
+                result[ext + "_size"] = "%d B" % (byte_size)
         data = json.dumps(result)
         self.write(data)
         self.set_header('Content-type', 'application/json')

--- a/bigg2/server.py
+++ b/bigg2/server.py
@@ -632,9 +632,12 @@ class ModelsListDisplayHandler(BaseHandler):
 
 class ModelDownloadHandler(BaseHandler):
     def get(self, model_bigg_id):
-        data = queries.get_model_json_string(model_bigg_id)
-        self.write(data)
+        json_path = join(static_model_dir, model_bigg_id + ".json")
+        if not isfile(json_path):
+            raise HTTPError(404)
         self.set_header('Content-type', 'application/json')
+        with open(json_path, "rb") as infile:
+            self.write(infile.read())
         self.finish()
 
 

--- a/bigg2/static/js/question_mark.js
+++ b/bigg2/static/js/question_mark.js
@@ -2,6 +2,7 @@ $(document).ready(function() {
     // question mark popovers
     $(function() {
         $('[data-toggle="popover"]').popover();
+        $('[data-toggle="tooltip"]').tooltip();
     });
     $('body').on('click touchstart', function (e) {
         $('[data-toggle="popover"]').each(function () {

--- a/bigg2/templates/json_link.html
+++ b/bigg2/templates/json_link.html
@@ -1,0 +1,16 @@
+{% if json_size %}
+JSON
+{% with question_title='MAT' %}
+    {% with question_text='COBRA models in JSON are primarily used by the Escher pathway map visualization tool. They can also be loaded by COBRApy v0.3 and later.' %}
+      {% include 'question_mark.html' %}
+    {% endwith %}
+{% endwith %}
+:&nbsp;
+<a href="/static/models/{{bigg_id}}.json"
+    download="{{bigg_id}}.json"
+    data-toggle="tooltip"
+    data-trigger="hover"
+    data-title="{{json_size}}"
+    >
+    {{bigg_id}}.json</a>
+{% endif %}

--- a/bigg2/templates/mat_link.html
+++ b/bigg2/templates/mat_link.html
@@ -1,0 +1,16 @@
+{% if mat_size %}
+MAT
+{% with question_title='MAT' %}
+    {% with question_text='This file is primarily for use with the COBRA toolbox. It can also be read by cobrapy.' %}
+      {% include 'question_mark.html' %}
+    {% endwith %}
+{% endwith %}
+:&nbsp;
+<a href="/static/models/{{bigg_id}}.mat"
+    download="{{bigg_id}}.mat"
+    data-toggle="tooltip"
+    data-trigger="hover"
+    data-title="{{mat_size}}"
+    >
+    {{bigg_id}}.mat</a>
+{% endif %}

--- a/bigg2/templates/model.html
+++ b/bigg2/templates/model.html
@@ -44,46 +44,42 @@
       </div>
 
       <h4>Download COBRA model from the BiGG Database:</h4>
-			COBRA model (JSON
-      {% with question_title='COBRA model: JSON format'%}
-        {% with question_text='COBRA model in JSON format can be read with COBRApy v0.3 and later and the Escher pathway map visualization tool.'%}
+			SBML
+      {% with question_title='SBML level 3 (v1) with FBC (v2)'%}
+        {% with question_text='This file is fully annotated through MIRIAM and uses version 2 of the FBC package. It is only readable by COBRApy v0.4 and later.'%}
           {% include 'question_mark.html' %}
         {% endwith %}
       {% endwith %}
-			):&nbsp;
-			<a href="/static/dumped_models/{{bigg_id}}.json" download="{{bigg_id}}.json">
+			:&nbsp;
+			<a href="/static/models/{{bigg_id}}.xml.gz" download="{{bigg_id}}.xml.gz">
+				{{bigg_id}}.xml.gz
+            </a>
+			<a href="/static/models/{{bigg_id}}.xml" download="{{bigg_id}}.xml">
+                <small>(uncompressed)</small>
+            </a>
+			<br/>
+			JSON
+      {% with question_title='JSON format'%}
+        {% with question_text='COBRA models in JSON are primarily used by the Escher pathway map visualization tool. They can also be loaded by COBRApy v0.3 and later.'%}
+          {% include 'question_mark.html' %}
+        {% endwith %}
+      {% endwith %}
+			:&nbsp;
+			<a href="/static/models/{{bigg_id}}.json" download="{{bigg_id}}.json">
 				{{bigg_id}}.json
-      </a>
+            </a>
 			<br/>
-			COBRA model (SBML
-      {% with question_title='COBRA model: SBML level 2 (v1)'%}
-        {% with question_text='This file uses a version of SBML which can by read by COBRApy and the COBRA toolbox.'%}
+			MAT
+      {% with question_title='MAT'%}
+        {% with question_text='This file is primarily for use with the COBRA toolbox. It can also be read by cobrapy'%}
           {% include 'question_mark.html' %}
         {% endwith %}
       {% endwith %}
-			):&nbsp;
-			<a href="/static/dumped_models/{{bigg_id}}.xml" download="{{bigg_id}}.xml">
-				{{bigg_id}}.xml
+			:&nbsp;
+			<a href="/static/models/{{bigg_id}}.mat" download="{{bigg_id}}.mat">
+                {{bigg_id}}.mat
 			</a>
 			<br/>
-			COBRA model (SBML with FBC v2 and MIRIAM
-      {% with question_title='COBRA model: SBML level 3 (v1) with FBC (v2)'%}
-        {% with question_text='This file is fully annotated through MIRIAM and uses the latest, unfinalized version of the FBC package (version 2). It is only readable by COBRApy v0.4 and later.'%}
-          {% include 'question_mark.html' %}
-        {% endwith %}
-      {% endwith %}
-			):&nbsp;
-			<a href="/static/polished_models/{{bigg_id}}.xml.zip" download="{{bigg_id}}.xml.zip">
-				{{bigg_id}}.xml.zip
-			</a>
-			<br/>
-			<br/>
-			{% if published_filename is not none %}
-				Published model:&nbsp;
-				<a href="/static/published_models/{{published_filename}}" download="{{published_filename}}">
-					{{published_filename}}
-				</a>
-			{% endif %}
 			<br/>
 			{% if reference_type == 'pmid' %}
 				Publication PMID:&nbsp;

--- a/bigg2/templates/model.html
+++ b/bigg2/templates/model.html
@@ -44,41 +44,11 @@
       </div>
 
       <h4>Download COBRA model from the BiGG Database:</h4>
-			SBML
-      {% with question_title='SBML level 3 (v1) with FBC (v2)'%}
-        {% with question_text='This file is fully annotated through MIRIAM and uses version 2 of the FBC package. It is only readable by COBRApy v0.4 and later.'%}
-          {% include 'question_mark.html' %}
-        {% endwith %}
-      {% endwith %}
-			:&nbsp;
-			<a href="/static/models/{{bigg_id}}.xml.gz" download="{{bigg_id}}.xml.gz">
-				{{bigg_id}}.xml.gz
-            </a>
-			<a href="/static/models/{{bigg_id}}.xml" download="{{bigg_id}}.xml">
-                <small>(uncompressed)</small>
-            </a>
-			<br/>
-			JSON
-      {% with question_title='JSON format'%}
-        {% with question_text='COBRA models in JSON are primarily used by the Escher pathway map visualization tool. They can also be loaded by COBRApy v0.3 and later.'%}
-          {% include 'question_mark.html' %}
-        {% endwith %}
-      {% endwith %}
-			:&nbsp;
-			<a href="/static/models/{{bigg_id}}.json" download="{{bigg_id}}.json">
-				{{bigg_id}}.json
-            </a>
-			<br/>
-			MAT
-      {% with question_title='MAT'%}
-        {% with question_text='This file is primarily for use with the COBRA toolbox. It can also be read by cobrapy'%}
-          {% include 'question_mark.html' %}
-        {% endwith %}
-      {% endwith %}
-			:&nbsp;
-			<a href="/static/models/{{bigg_id}}.mat" download="{{bigg_id}}.mat">
-                {{bigg_id}}.mat
-			</a>
+      {% include 'sbml_link.html' %}
+      <br/>
+      {% include 'json_link.html' %}
+      <br/>
+      {% include 'mat_link.html' %}
 			<br/>
 			<br/>
 			{% if reference_type == 'pmid' %}

--- a/bigg2/templates/question_mark.html
+++ b/bigg2/templates/question_mark.html
@@ -1,7 +1,7 @@
 <a tabindex="0" role="button" type="button" class="btn btn-default btn-xs"
-   style="position: relative; top: -8px;" data-trigger="click"
+   style="position: relative; top: -8px; padding: 0.2em; height: 1.8em;" data-trigger="click"
    data-toggle="popover" data-placement="bottom"
    data-title="{{question_title}}"
    data-content="{{question_text}}">
-  ?
+   ?
 </a>

--- a/bigg2/templates/sbml_link.html
+++ b/bigg2/templates/sbml_link.html
@@ -1,0 +1,22 @@
+{% if xml_gz_size %}
+SBML
+{% with question_title='SBML level 3 (v1) with FBC (v2)'%}
+    {% with question_text='This file is fully annotated through MIRIAM and uses version 2 of the FBC package. It is only readable by COBRApy v0.4 and later.' %}
+      {% include 'question_mark.html' %}
+    {% endwith %}
+{% endwith %}
+:&nbsp;
+<a href="/static/models/{{bigg_id}}.xml.gz"
+    download="{{bigg_id}}.xml.gz"
+    data-toggle="tooltip"
+    data-trigger="hover"
+    data-title="{{xml_gz_size}}"
+    >
+    {{bigg_id}}.xml.gz</a>
+(<a href="/static/models/{{bigg_id}}.xml"
+    download="{{bigg_id}}.xml"
+    data-toggle="tooltip"
+    data-trigger="hover"
+    data-title="{{xml_size}}"
+    ><small>uncompressed</small></a>)
+{% endif %}

--- a/bigg2/templates/sbml_link.html
+++ b/bigg2/templates/sbml_link.html
@@ -13,10 +13,12 @@ SBML
     data-title="{{xml_gz_size}}"
     >
     {{bigg_id}}.xml.gz</a>
+<small>
 (<a href="/static/models/{{bigg_id}}.xml"
     download="{{bigg_id}}.xml"
     data-toggle="tooltip"
     data-trigger="hover"
     data-title="{{xml_size}}"
-    ><small>uncompressed</small></a>)
+    >uncompressed</small></a>)
+</small>
 {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from os.path import join, dirname, realpath
+from os.path import join, dirname, abspath
 
-try:
-    from setuptools import setup, Command
-except:
-    from distutils.core import setup, Command
+from setuptools import setup, Command
 
 # this is a trick to get the version before the package is installed
-directory = dirname(realpath(__file__))
+directory = dirname(abspath(__file__))
 sys.path.insert(0, join(directory, 'bigg2'))
 version = __import__('version').__version__
 
@@ -22,8 +19,10 @@ setup(name='BiGG 2',
                              'static/js/*', 'static/lib/*',
                              'static/lib/tablesorter/*',
                              'templates/*']},
+      entry_points={"console_scripts":
+                    ['make_all_static_models = '
+                     'bigg2.model_dumper:make_all_static_models']},
       install_requires=['Jinja2>=2.7.3',
                         'tornado>=4.0.2',
                         'pytest>=2.6.2',
-                        'python-libsbml>=5.11.4', # may require sudo
                         'ome==0.0.1-bigg'])


### PR DESCRIPTION
Now only SBML3+fbcv2, JSON, mat, and JSON downloads.

This fixes #116 and #107.

This also includes a script to generate all dumped sbml models.