### PR TITLE
error textarea scales to page width

### DIFF
--- a/bigg2/templates/comments.html
+++ b/bigg2/templates/comments.html
@@ -35,7 +35,7 @@
       </select>
       <h4>Please describe the error</h4>
       <div class="form-inline" role="form">
-        <textarea class="form-control" name="comments" rows="3" cols="100" placeholder="Comments"></textarea>
+        <textarea class="form-control" name="comments" rows="3" style="width: 100%;" placeholder="Comments"></textarea>
         <br/><br/>
         <button class="btn btn-default" id="submit" type="submit" value="Submit">Submit</button>
         <br/><br/>


### PR DESCRIPTION
No longer extends beyond parent, like this:

![screenshot 2015-07-22 at 12 17 22 am](https://cloud.githubusercontent.com/assets/1380168/8820072/1360ee20-3007-11e5-8483-f40a8533c5a2.png)
