### PR TITLE
implement gzip_static feature from nginx

### DIFF
--- a/bigg2/model_dumper.py
+++ b/bigg2/model_dumper.py
@@ -103,12 +103,16 @@ def write_static_model(bigg_id, model_polisher_path=None):
 
     print('Writing MAT')
     t = time.time()
-    cobra.io.save_matlab_model(model, join(static_dir, bigg_id + '.mat'))
+    mat_filepath = join(static_dir, bigg_id + '.mat')
+    cobra.io.save_matlab_model(model, mat_filepath)
+    system('gzip --keep --force --best ' + mat_filepath)
     print('Writing MAT finished in %.2f seconds' % (time.time() - t))
 
     print('Writing JSON')
     t = time.time()
-    cobra.io.save_json_model(model, join(static_dir, bigg_id + '.json'))
+    json_filepath = join(static_dir, bigg_id + ".json")
+    cobra.io.save_json_model(model, json_filepath)
+    system('gzip --keep --force --best ' + json_filepath)
     print('Writing JSON finished in %.2f seconds' % (time.time() - t))
 
     return success

--- a/bigg2/server.py
+++ b/bigg2/server.py
@@ -1129,9 +1129,20 @@ class LicenseHandler(BaseHandler):
 
 # static files
 class StaticFileHandlerWithEncoding(StaticFileHandler):
+    # This is only to opportunisticly use a pre-compressed file
+    # (equivalent to gzip_static in nginx).
+    def get_absolute_path(self, root, path):
+        p = abspath(join(root, path))
+        # if the client accepts gzip
+        if "gzip" in self.request.headers.get('Accept-Encoding', ''):
+            if isfile(p + ".gz"):
+                self.set_header("Content-Encoding", "gzip")
+                return p + ".gz"
+        return p
+
     def get_content_type(self):
         """Same as the default, except that we add a utf8 encoding for XML and JSON files."""
-        mime_type, encoding = mimetypes.guess_type(self.absolute_path)
+        mime_type, encoding = mimetypes.guess_type(self.path)
 
         # from https://github.com/tornadoweb/tornado/pull/1468
         # per RFC 6713, use the appropriate type for a gzip compressed file


### PR DESCRIPTION
If a gzip compressed version of a static file and the client supports
gzip encoding, use that instead.

For example, this will let us just link to the uncompressed xml, and the
compressed version will be served and transparently uncompressed for
SBML models.